### PR TITLE
Fix link to commitlint and cz-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,10 +348,10 @@ Blog posts about how to write git commit messages:
 
 Tools that help with git commit messages:
 
-  * [commitlint: a command line tool to lint git commit messages](https://github.com/marionebl/commitlint)
+  * [commitlint: a command line tool to lint git commit messages](https://conventional-changelog.github.io/commitlint/)
 
   * [husky: git hooks made easy](https://github.com/typicode/husky)
 
-  * [commitizen command line utility](https://github.com/commitizen/cz-cli)
+  * [commitizen command line utility](http://commitizen.github.io/cz-cli/)
 
   * [conventional-changelog: generate changelogs and release notes from a project's commit messages and metadata](https://github.com/conventional-changelog/conventional-changelog)


### PR DESCRIPTION
commitlint got a new home:

![grafik](https://user-images.githubusercontent.com/1366654/52912361-be4f1f00-32b0-11e9-94ed-3b27574170fb.png)

I pointed to the well-rendered homepage (and not to the GitHub repo).

cz-cli got a homepage. I also changed the link there to point to the user-documentation not to the code repo.